### PR TITLE
Fix Carthage build

### DIFF
--- a/ReSwift-Thunk.xcodeproj/project.pbxproj
+++ b/ReSwift-Thunk.xcodeproj/project.pbxproj
@@ -302,7 +302,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ReSwift_Thunk;
 				RESOURCES_TARGETED_DEVICE_FAMILY = "";
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos macosx";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -372,7 +371,6 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = ReSwift_Thunk;
 				RESOURCES_TARGETED_DEVICE_FAMILY = "";
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos macosx";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";


### PR DESCRIPTION
I dunno what happened in #6 but this seems to build fine, also this works:

```
$ echo "github \"ReSwift/ReSwift-Thunk\" \"carthage-fix\"" > Cartfile
$ carthage bootstrap
*** No Cartfile.resolved found, updating dependencies
*** Fetching ReSwift-Thunk
*** Fetching ReSwift
*** Checking out ReSwift at "4.0.1"
*** Checking out ReSwift-Thunk at "a6e02c1651b582d224cde9c558ba22d3618dcc56"
*** xcodebuild output can be found in /var/folders/62/8k21681d08z9lhq8h433z3rh0000gp/T/carthage-xcodebuild.4rYFQw.log
*** Downloading ReSwift.framework binary at "4.0.1"
***  Skipped installing ReSwift.framework binary due to the error:
	"Incompatible Swift version - framework was built with 3.1 (swiftlang-802.0.53 clang-802.0.42) and the local version is 4.2.1 (swiftlang-1000.11.42 clang-1000.11.45.1)."

    Falling back to building from the source
*** Building scheme "ReSwift-macOS" in ReSwift.xcworkspace
*** Building scheme "ReSwift-watchOS" in ReSwift.xcworkspace
*** Building scheme "ReSwift-tvOS" in ReSwift.xcworkspace
*** Building scheme "ReSwift-iOS" in ReSwift.xcworkspace
*** Building scheme "ReSwift-Thunk" in ReSwift-Thunk.xcodeproj
```

So, good to go and then try CocoaPods next :) 