### PR TITLE
Add deprecated forwards for migration from mikecole20/ReSwiftThunk

### DIFF
--- a/ReSwift-Thunk/Thunk.swift
+++ b/ReSwift-Thunk/Thunk.swift
@@ -17,3 +17,6 @@ public struct Thunk<State: StateType>: Action {
         self.body = body
     }
 }
+
+@available(*, deprecated, renamed: "Thunk")
+typealias ThunkAction = Thunk

--- a/ReSwift-Thunk/createThunksMiddleware.swift
+++ b/ReSwift-Thunk/createThunksMiddleware.swift
@@ -23,3 +23,10 @@ public func createThunksMiddleware<State: StateType>() -> Middleware<State> {
         }
     }
 }
+
+// swiftlint:disable identifier_name
+@available(*, deprecated, renamed: "createThunksMiddleware")
+func ThunkMiddleware<State: StateType>() -> Middleware<State> {
+    return createThunksMiddleware()
+}
+// swiftlint:enable identifier_name


### PR DESCRIPTION
Adds typealias & function forwards for compatibility with users upgrading from https://github.com/mikecole20/ReSwiftThunk