### PR TITLE
Remove StateType protocol restrictions

### DIFF
--- a/ReSwift-Thunk/Thunk.swift
+++ b/ReSwift-Thunk/Thunk.swift
@@ -9,7 +9,7 @@
 import Foundation
 import ReSwift
 
-public struct Thunk<State: StateType>: Action {
+public struct Thunk<State>: Action {
     let body: (_ dispatch: @escaping DispatchFunction, _ getState: @escaping () -> State?) -> Void
     public init(body: @escaping (
         _ dispatch: @escaping DispatchFunction,

--- a/ReSwift-Thunk/createThunksMiddleware.swift
+++ b/ReSwift-Thunk/createThunksMiddleware.swift
@@ -9,7 +9,7 @@
 import Foundation
 import ReSwift
 
-public func createThunksMiddleware<State: StateType>() -> Middleware<State> {
+public func createThunksMiddleware<State>() -> Middleware<State> {
     return { dispatch, getState in
         return { next in
             return { action in

--- a/ReSwift-ThunkTests/Tests.swift
+++ b/ReSwift-ThunkTests/Tests.swift
@@ -13,6 +13,9 @@ import ReSwift
 
 private struct FakeState: StateType {}
 private struct FakeAction: Action {}
+private func fakeReducer(action: Action, state: FakeState?) -> FakeState {
+    return state ?? FakeState()
+}
 
 class Tests: XCTestCase {
 
@@ -40,5 +43,19 @@ class Tests: XCTestCase {
         middleware(dispatch, getState)(next)(thunk)
         XCTAssertFalse(nextCalled)
         XCTAssert(thunkBodyCalled)
+    }
+
+    func testMiddlewareInsertion() {
+        let store = Store(
+            reducer: fakeReducer,
+            state: nil,
+            middleware: [createThunksMiddleware()]
+        )
+        var thunkBodyCalled = false
+        let thunk = Thunk<FakeState> { _, _ in
+            thunkBodyCalled = true
+        }
+        store.dispatch(thunk)
+        XCTAssertTrue(thunkBodyCalled)
     }
 }


### PR DESCRIPTION
This restriction is unnecessary and would prevent creating thunks that use protocols that are a subset of the users main state.

This also will help allow for seamless upgrading from https://github.com/mikecole20/ReSwiftThunk since the type restrictions now match.