### PR TITLE
Reduce Cocoapods documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,6 @@ ReSwift-Thunk requires the [ReSwift](https://github.com/ReSwift/ReSwift/) base m
 
 You can install ReSwift-Thunk via CocoaPods by adding it to your `Podfile`:
 ```
-use_frameworks!
-
-source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
-
-pod 'ReSwift'
 pod 'ReSwiftThunk'
 ```
 


### PR DESCRIPTION
The content around here is not necessary. For one, it can be assumed that a user already has cocoapods installed and has followed their instructions for creating a podfile, and for two, its not required to specify sub-dependencies such as `ReSwift`, Cocoapods will automatically detect that and install it since its specified in the podspec dependencies.

[ci skip]