### PR TITLE
Rename `createThunksMiddleware` to `createThunkMiddleware`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Breaking API Changes:**
 
 **API Changes:**
+- Renames `createThunksMiddleware` to `createThunkMiddleware` and adds deprecated forwards for `createThunksMiddleware` (#20) - @fbernutz
 
 **Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Breaking API Changes:**
 
 **API Changes:**
-- Renames `createThunksMiddleware` to `createThunkMiddleware` and adds deprecated forwards for `createThunksMiddleware` (#20) - @fbernutz
+- Renames `createThunksMiddleware` to `createThunkMiddleware` and adds deprecated forward for `createThunksMiddleware` (#20) - @fbernutz
 
 **Fixes:**
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When [ReSwift](https://github.com/ReSwift/ReSwift/) is a [Redux](https://github.
 
 ```swift
 // First, you create the middleware, which needs to know the type of your `State`.
-let thunksMiddleware: Middleware<MyState> = createThunksMiddleware()
+let thunksMiddleware: Middleware<MyState> = createThunkMiddleware()
 
 // Note that it can perfectly live with other middleware in the chain.
 let store = Store<MyState>(reducer: reducer, state: nil, middleware: [thunksMiddleware])

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ When [ReSwift](https://github.com/ReSwift/ReSwift/) is a [Redux](https://github.
 
 ```swift
 // First, you create the middleware, which needs to know the type of your `State`.
-let thunksMiddleware: Middleware<MyState> = createThunkMiddleware()
+let thunkMiddleware: Middleware<MyState> = createThunkMiddleware()
 
 // Note that it can perfectly live with other middleware in the chain.
-let store = Store<MyState>(reducer: reducer, state: nil, middleware: [thunksMiddleware])
+let store = Store<MyState>(reducer: reducer, state: nil, middleware: [thunkMiddleware])
 
 // A thunk represents an action that can perform side effects, access the current state of the store, and dispatch new actions, as if it were a ReSwift middleware.
 let thunk = Thunk<MyState> { dispatch, getState in 

--- a/ReSwift-Thunk.xcodeproj/project.pbxproj
+++ b/ReSwift-Thunk.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		65A3D6E6218B89A60075CB92 /* ReSwift_Thunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 65A3D6D8218B89A60075CB92 /* ReSwift_Thunk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65A3D6F0218B8A300075CB92 /* Thunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A3D6EF218B8A300075CB92 /* Thunk.swift */; };
 		65A3D6F3218C91F20075CB92 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65A3D6F2218C91F20075CB92 /* ReSwift.framework */; };
-		65A3D6F5218C92420075CB92 /* createThunksMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A3D6F4218C92420075CB92 /* createThunksMiddleware.swift */; };
+		65A3D6F5218C92420075CB92 /* createThunkMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A3D6F4218C92420075CB92 /* createThunkMiddleware.swift */; };
 		D28E4F562214F37100DEFA7D /* ExpectThunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E4F552214F37100DEFA7D /* ExpectThunk.swift */; };
 /* End PBXBuildFile section */
 
@@ -35,7 +35,7 @@
 		65A3D6E5218B89A60075CB92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65A3D6EF218B8A300075CB92 /* Thunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thunk.swift; sourceTree = "<group>"; };
 		65A3D6F2218C91F20075CB92 /* ReSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReSwift.framework; path = Carthage/Build/iOS/ReSwift.framework; sourceTree = "<group>"; };
-		65A3D6F4218C92420075CB92 /* createThunksMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = createThunksMiddleware.swift; sourceTree = "<group>"; };
+		65A3D6F4218C92420075CB92 /* createThunkMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = createThunkMiddleware.swift; sourceTree = "<group>"; };
 		D28E4F552214F37100DEFA7D /* ExpectThunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectThunk.swift; sourceTree = "<group>"; };
 		D4286E7721EFED3F00D5749B /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		D4286E7821EFED4D00D5749B /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -88,7 +88,7 @@
 				65A3D6D8218B89A60075CB92 /* ReSwift_Thunk.h */,
 				65A3D6D9218B89A60075CB92 /* Info.plist */,
 				65A3D6EF218B8A300075CB92 /* Thunk.swift */,
-				65A3D6F4218C92420075CB92 /* createThunksMiddleware.swift */,
+				65A3D6F4218C92420075CB92 /* createThunkMiddleware.swift */,
 			);
 			path = "ReSwift-Thunk";
 			sourceTree = "<group>";
@@ -220,7 +220,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65A3D6F5218C92420075CB92 /* createThunksMiddleware.swift in Sources */,
+				65A3D6F5218C92420075CB92 /* createThunkMiddleware.swift in Sources */,
 				65A3D6F0218B8A300075CB92 /* Thunk.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReSwift-Thunk/createThunkMiddleware.swift
+++ b/ReSwift-Thunk/createThunkMiddleware.swift
@@ -30,3 +30,8 @@ func ThunkMiddleware<State: StateType>() -> Middleware<State> {
     return createThunkMiddleware()
 }
 // swiftlint:enable identifier_name
+
+@available(*, deprecated, renamed: "createThunkMiddleware")
+func createThunksMiddleware<State: StateType>() -> Middleware<State> {
+    return createThunkMiddleware()
+}

--- a/ReSwift-Thunk/createThunkMiddleware.swift
+++ b/ReSwift-Thunk/createThunkMiddleware.swift
@@ -1,5 +1,5 @@
 //
-//  createThunksMiddleware.swift
+//  createThunkMiddleware.swift
 //  ReSwift-Thunk
 //
 //  Created by Daniel Martín Prieto on 02/11/2018.
@@ -9,7 +9,7 @@
 import Foundation
 import ReSwift
 
-public func createThunksMiddleware<State>() -> Middleware<State> {
+public func createThunkMiddleware<State>() -> Middleware<State> {
     return { dispatch, getState in
         return { next in
             return { action in
@@ -25,8 +25,8 @@ public func createThunksMiddleware<State>() -> Middleware<State> {
 }
 
 // swiftlint:disable identifier_name
-@available(*, deprecated, renamed: "createThunksMiddleware")
+@available(*, deprecated, renamed: "createThunkMiddleware")
 func ThunkMiddleware<State: StateType>() -> Middleware<State> {
-    return createThunksMiddleware()
+    return createThunkMiddleware()
 }
 // swiftlint:enable identifier_name

--- a/ReSwift-ThunkTests/ExpectThunk.swift
+++ b/ReSwift-ThunkTests/ExpectThunk.swift
@@ -114,7 +114,7 @@ extension ExpectThunk {
 extension ExpectThunk {
     @discardableResult
     public func run(file: StaticString = #file, line: UInt = #line) -> Self {
-        createThunksMiddleware()(dispatch, getState)({ _ in })(thunk)
+        createThunkMiddleware()(dispatch, getState)({ _ in })(thunk)
         failLeftovers()
         return self
     }
@@ -137,7 +137,7 @@ extension ExpectThunk {
                 expectation.fulfill()
             }
         }
-        createThunksMiddleware()(dispatch, getState)({ _ in })(thunk)
+        createThunkMiddleware()(dispatch, getState)({ _ in })(thunk)
         return self
     }
 

--- a/ReSwift-ThunkTests/Tests.swift
+++ b/ReSwift-ThunkTests/Tests.swift
@@ -21,7 +21,7 @@ private func fakeReducer(action: Action, state: FakeState?) -> FakeState {
 class Tests: XCTestCase {
 
     func testAction() {
-        let middleware: Middleware<FakeState> = createThunksMiddleware()
+        let middleware: Middleware<FakeState> = createThunkMiddleware()
         let dispatch: DispatchFunction = { _ in }
         let getState: () -> FakeState? = { nil }
         var nextCalled = false
@@ -32,7 +32,7 @@ class Tests: XCTestCase {
     }
 
     func testThunk() {
-        let middleware: Middleware<FakeState> = createThunksMiddleware()
+        let middleware: Middleware<FakeState> = createThunkMiddleware()
         let dispatch: DispatchFunction = { _ in }
         let getState: () -> FakeState? = { nil }
         var nextCalled = false
@@ -50,7 +50,7 @@ class Tests: XCTestCase {
         let store = Store(
             reducer: fakeReducer,
             state: nil,
-            middleware: [createThunksMiddleware()]
+            middleware: [createThunkMiddleware()]
         )
         var thunkBodyCalled = false
         let thunk = Thunk<FakeState> { _, _ in


### PR DESCRIPTION
Fixes #20 

Renames `createThunksMiddleware` to `createThunkMiddleware` and add deprecated typealias for old spelling. 