### PR TITLE
Run pod linter for one Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: objective-c
 
-before_install:
-  - gem install cocoapods -v '1.7.5'
-
-install:
-  - gem install xcpretty
-
 env:
   global:
     - LC_CTYPE=en_US.UTF-8
@@ -28,7 +22,11 @@ matrix:
       env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="5.0" ACTION="build"
 
 before_install:
+  - gem install cocoapods -v '1.7.5'
   - carthage bootstrap --platform "$SCHEME" --verbose
+
+install:
+  - gem install xcpretty
 
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ matrix:
       env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="5.0" ACTION="build"
 
 before_install:
-  - gem install cocoapods -v '1.7.5'
+  - if [ $POD_LINT == "YES" ]; then
+      gem install cocoapods -v '1.7.5';
+      pod repo update;
+    fi
   - carthage bootstrap --platform "$SCHEME" --verbose
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: objective-c
 
+before_install:
+  - gem install cocoapods -v '1.7.5'
+
 install:
   - gem install xcpretty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - osx_image: xcode10.1
       env: SCHEME="macOS"  SDK="macosx10.14"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.2
-      env: SCHEME="macOS"  SDK="macosx10.14"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="5.0" ACTION="test"
+      env: SCHEME="macOS"  SDK="macosx10.14"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="5.0" ACTION="test" POD_LINT="YES"
     - osx_image: xcode10.2
       env: SCHEME="iOS"    SDK="iphonesimulator"      DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="5.0" ACTION="test"
     - osx_image: xcode10.2
@@ -42,6 +42,9 @@ script:
     GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
     GCC_GENERATE_TEST_COVERAGE_FILES=YES
     SWIFT_VERSION=$SWIFT_VERSION
+  - if [ $POD_LINT == "YES" ]; then
+      pod lib lint --verbose;
+    fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J ReSwift-Thunk


### PR DESCRIPTION
This will, sadly, reveal a pod lint error regarding the `ExpectThunk` spec. I suggest we merge this in anyway to get automatic feedback and fix the `ExpectThunk` issue separately.