### PR TITLE
Make `.run()` or `.wait()` required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Other:**
 
+- `ExpectThunk`'s methods `dispatches` and `getsState` no longer have `@discardableResult` return values
+
 # 1.2.0
 
 **API Changes:**

--- a/ReSwift-ThunkTests/ExpectThunk.swift
+++ b/ReSwift-ThunkTests/ExpectThunk.swift
@@ -57,7 +57,6 @@ public class ExpectThunk<State: StateType> {
 }
 
 extension ExpectThunk {
-    @discardableResult
     public func dispatches<A: Action & Equatable>(_ expected: A,
                                                   file: StaticString = #file,
                                                   line: UInt = #line) -> Self {
@@ -78,7 +77,6 @@ extension ExpectThunk {
         return self
     }
 
-    @discardableResult
     public func dispatches(file: StaticString = #file,
                            line: UInt = #line,
                            dispatch assertion: @escaping DispatchFunction) -> Self {
@@ -95,7 +93,6 @@ extension ExpectThunk {
 }
 
 extension ExpectThunk {
-    @discardableResult
     public func getsState(_ state: State,
                           file: StaticString = #file,
                           line: UInt = #line) -> Self {


### PR DESCRIPTION
Currently, the `ExpectThunk` methods `dispatches` and `getsState` are marked with `@discardableResult`, so the following code compiles (and runs) without errors or warnings:

```swift
func testExpectThunk() {
    let thunk = someThunk

    ExpectThunk(thunk)
        .dispatches { _ in XCTFail() }
}
```

As far as I can tell, there is no point in using `ExpectThunk` without calling `run` or `wait` on it.

This PR removes the `@discardableResult` from said methods, so the compiler will now generate a warning, notifying the user that the result is unused.