### PR TITLE
chore: Update Package.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 **Other:**
 
+# 1.3.0
+
+**Other:**
+- Rename Swift packager manager library to `ReSwiftThunk`, this makes naming consistent across all package manager (Cocoapods, Carthage and SPM)
+
 # 1.2.0
 
 **API Changes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,8 @@
 **Fixes:**
 
 **Other:**
+- Rename SwiftPM library to `ReSwiftThunk`, this makes naming consistent across all package manager (Cocoapods, Carthage and SwiftPM)
 
-# 1.3.0
-
-**Other:**
-- Rename Swift packager manager library to `ReSwiftThunk`, this makes naming consistent across all package manager (Cocoapods, Carthage and SPM)
 
 # 1.2.0
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,16 +3,16 @@
 import PackageDescription
 
 let package = Package(
-    name: "ReSwift-Thunk",
+    name: "ReSwiftThunk",
     products: [
-      .library(name: "ReSwift-Thunk", targets: ["ReSwift-Thunk"])
+      .library(name: "ReSwiftThunk", targets: ["ReSwiftThunk"])
     ],
     dependencies: [
       .package(url: "https://github.com/ReSwift/ReSwift", .upToNextMajor(from: "5.0.0"))
     ],
     targets: [
       .target(
-        name: "ReSwift-Thunk",
+        name: "ReSwiftThunk",
         dependencies: [
           "ReSwift"
         ],


### PR DESCRIPTION
Removing the dash from the package name makes Swift package manager behave. It nog longer replaces the dash with an underscore. 