### PR TITLE
remove obsolete StateType requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **API Changes:**
 
+- Remove deprecated `StateType` protocol requirement (#48) - @DivineDominion, @mjarvis
+
 **Fixes:**
 
 # 2.0.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-# github "ReSwift/ReSwift" ~> 6.0.0
+# github "ReSwift/ReSwift" ~> 6.1.0
 # Use master until new version is ready
 github "ReSwift/ReSwift" "master"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,3 @@
-github "ReSwift/ReSwift" ~> 6.0.0
+# github "ReSwift/ReSwift" ~> 6.0.0
+# Use master until new version is ready
+github "ReSwift/ReSwift" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" "6.0.0"
+github "ReSwift/ReSwift" "4ef9ab80d3905749e1c69a5b4f1dee1d83615c8d"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" "4ef9ab80d3905749e1c69a5b4f1dee1d83615c8d"
+github "ReSwift/ReSwift" "95b81b75f26d467bb624939a92189b1bae3e7b27"

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
       .library(name: "ReSwiftThunk", targets: ["ReSwiftThunk"])
     ],
     dependencies: [
-      .package(url: "https://github.com/ReSwift/ReSwift", .upToNextMajor(from: "6.0.0"))
+      .package(url: "https://github.com/ReSwift/ReSwift", .upToNextMajor(from: "6.1.0"))
     ],
     targets: [
       .target(

--- a/ReSwift-Thunk/createThunkMiddleware.swift
+++ b/ReSwift-Thunk/createThunkMiddleware.swift
@@ -26,12 +26,12 @@ public func createThunkMiddleware<State>() -> Middleware<State> {
 
 // swiftlint:disable identifier_name
 @available(*, deprecated, renamed: "createThunkMiddleware")
-func ThunkMiddleware<State: StateType>() -> Middleware<State> {
+func ThunkMiddleware<State>() -> Middleware<State> {
     return createThunkMiddleware()
 }
 // swiftlint:enable identifier_name
 
 @available(*, deprecated, renamed: "createThunkMiddleware")
-func createThunksMiddleware<State: StateType>() -> Middleware<State> {
+func createThunksMiddleware<State>() -> Middleware<State> {
     return createThunkMiddleware()
 }

--- a/ReSwift-ThunkTests/ExpectThunk.swift
+++ b/ReSwift-ThunkTests/ExpectThunk.swift
@@ -31,7 +31,7 @@ private struct ExpectThunkAssertion<T> {
     }
 }
 
-public class ExpectThunk<State: StateType> {
+public class ExpectThunk<State> {
     private var dispatch: DispatchFunction {
         return { action in
             self.dispatched.append(action)

--- a/ReSwift-ThunkTests/Tests.swift
+++ b/ReSwift-ThunkTests/Tests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 import ReSwift
 
-private struct FakeState: StateType {}
+private struct FakeState {}
 private struct FakeAction: Action {}
 private struct AnotherFakeAction: Action, Equatable {}
 private func fakeReducer(action: Action, state: FakeState?) -> FakeState {

--- a/ReSwiftThunk.podspec
+++ b/ReSwiftThunk.podspec
@@ -1,6 +1,7 @@
+
 Pod::Spec.new do |spec|
   spec.name         = "ReSwiftThunk"
-  spec.version      = "2.0.1"
+  spec.version      = "2.1.0"
   spec.summary      = "Thunk middleware for ReSwift."
   spec.description  = <<-DESC
                       ReSwift-Thunk allows you to write action creators that return a function instead of an action. Instead of dispatching an `Action` directly, you can dispatch a `Thunk` that creates an action at a later time, for example after a network request finishes.
@@ -37,5 +38,5 @@ Pod::Spec.new do |spec|
 
   spec.default_subspec = "Core"
 
-  spec.dependency "ReSwift", "~> 6.0"
+  spec.dependency "ReSwift", "~> 6.1"
 end


### PR DESCRIPTION
ReSwift#462 got rid of the `StateType` protocol. This change reflects the ReSwift HEAD state.