### PR TITLE
add optional label that shows in the object description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Breaking API Changes:**
 
 **API Changes:**
+- Add optional `label` property to `Thunk` that is used for the object `description`, e.g for logging/printing the thunk object (#50) - @DivineDominion
 
 **Fixes:**
 
@@ -21,7 +22,7 @@
 **Other:**
 - Rename SwiftPM library to `ReSwiftThunk`, this makes naming consistent across all package manager (Cocoapods, Carthage and SwiftPM) (#42) - @jookes
 - `ExpectThunk`'s methods `dispatches` and `getsState` no longer have `@discardableResult` return values (#40) - @xavierLowmiller
--
+
 # 1.2.0
 
 **API Changes:**

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ let thunk = Thunk<MyState> { dispatch, getState in
 
 // A thunk can also be a function if you want to pass on parameters
 func thunkWithParams(_ identifier: Int) -> Thunk<MyState> {
-    return Thunk<MyState> { dispatch, getState in
+    let label = "Getting something for ID \(identifier)"
+    return Thunk<MyState>(label: label) { dispatch, getState in
         guard let state = getState() else { return }
         
         if state.loading {

--- a/ReSwift-Thunk/Thunk.swift
+++ b/ReSwift-Thunk/Thunk.swift
@@ -9,12 +9,20 @@
 import Foundation
 import ReSwift
 
-public struct Thunk<State>: Action {
+public struct Thunk<State>: Action, CustomStringConvertible {
     let body: (_ dispatch: @escaping DispatchFunction, _ getState: @escaping () -> State?) -> Void
-    public init(body: @escaping (
-        _ dispatch: @escaping DispatchFunction,
-        _ getState: @escaping () -> State?) -> Void) {
+    public let label: String?
+
+    public init(label: String? = nil,
+                body: @escaping (_ dispatch: @escaping DispatchFunction,
+                                 _ getState: @escaping () -> State?) -> Void) {
         self.body = body
+        self.label = label
+    }
+
+    public var description: String {
+        let label = self.label.map { "label: \"\($0)\"" } ?? ""
+        return "\(type(of: self))(\(label))"
     }
 }
 

--- a/ReSwift-ThunkTests/Tests.swift
+++ b/ReSwift-ThunkTests/Tests.swift
@@ -20,6 +20,15 @@ private func fakeReducer(action: Action, state: FakeState?) -> FakeState {
 
 class Tests: XCTestCase {
 
+    func testDescription() {
+        XCTAssertEqual("Thunk<FakeState>(label: \"With Label\")",
+                       Thunk<FakeState>(label: "With Label", body: { _, _ in }).description)
+        XCTAssertEqual("Thunk<FakeState>()",
+                       Thunk<FakeState>(label: nil, body: { _, _ in }).description)
+        XCTAssertEqual("Thunk<FakeState>()",
+                       Thunk<FakeState>(body: { _, _ in }).description)
+    }
+
     func testAction() {
         let middleware: Middleware<FakeState> = createThunkMiddleware()
         let dispatch: DispatchFunction = { _ in }


### PR DESCRIPTION
Motivation: In my app, I log all actions. This helps with debugging. But sprinkled in now are non-descript log messages like:

    💚 11:47:08: > Thunk<AppState>(body: (Function))
    💚 11:47:09: > Thunk<AppState>(body: (Function))
    💚 11:47:10: > Thunk<AppState>(body: (Function))

With the customizable description, users would be able to see which thunk is being dispatched, e.g.

    💚 11:47:08: > Thunk<AppState>(label: "Requesting users")
    💚 11:47:09: > Thunk<AppState>(label: "Requesting images for user XYZ")
    💚 11:47:09: > Thunk<AppState>(label: "Requesting images for user ABC")

What do y'all think about that?
