### PR TITLE
Remove deperecated StateType conformance

### DIFF
--- a/ReSwift-Thunk/createThunkMiddleware.swift
+++ b/ReSwift-Thunk/createThunkMiddleware.swift
@@ -26,12 +26,12 @@ public func createThunkMiddleware<State>() -> Middleware<State> {
 
 // swiftlint:disable identifier_name
 @available(*, deprecated, renamed: "createThunkMiddleware")
-func ThunkMiddleware<State: StateType>() -> Middleware<State> {
+func ThunkMiddleware<State>() -> Middleware<State> {
     return createThunkMiddleware()
 }
 // swiftlint:enable identifier_name
 
 @available(*, deprecated, renamed: "createThunkMiddleware")
-func createThunksMiddleware<State: StateType>() -> Middleware<State> {
+func createThunksMiddleware<State>() -> Middleware<State> {
     return createThunkMiddleware()
 }

--- a/ReSwift-ThunkTests/ExpectThunk.swift
+++ b/ReSwift-ThunkTests/ExpectThunk.swift
@@ -31,7 +31,7 @@ private struct ExpectThunkAssertion<T> {
     }
 }
 
-public class ExpectThunk<State: StateType> {
+public class ExpectThunk<State> {
     private var dispatch: DispatchFunction {
         return { action in
             self.dispatched.append(action)

--- a/ReSwift-ThunkTests/Tests.swift
+++ b/ReSwift-ThunkTests/Tests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 import ReSwift
 
-private struct FakeState: StateType {}
+private struct FakeState {}
 private struct FakeAction: Action {}
 private struct AnotherFakeAction: Action, Equatable {}
 private func fakeReducer(action: Action, state: FakeState?) -> FakeState {


### PR DESCRIPTION
`StateType is deprecated in recent versions of ReSwift. This PR removes the use of this protocol.