### PR TITLE
Add ExpectThunk target to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "ReSwiftThunk",
     products: [
       .library(name: "ReSwiftThunk", targets: ["ReSwiftThunk"]),
-      .library(name: "ExpectThunk", targets: ["ExpectThunk"])
+      .library(name: "ReSwiftThunkTesting", targets: ["ReSwiftThunkTesting"])
     ],
     dependencies: [
       .package(url: "https://github.com/ReSwift/ReSwift", .upToNextMajor(from: "6.0.0"))
@@ -20,7 +20,7 @@ let package = Package(
         path: "ReSwift-Thunk"
       ),
       .target(
-        name: "ExpectThunk",
+        name: "ReSwiftThunkTesting",
         path: "ReSwift-ThunkTests/",
         sources: ["ExpectThunk.swift"]
       )

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 let package = Package(
     name: "ReSwiftThunk",
     products: [
-      .library(name: "ReSwiftThunk", targets: ["ReSwiftThunk"])
+      .library(name: "ReSwiftThunk", targets: ["ReSwiftThunk"]),
+      .library(name: "ExpectThunk", targets: ["ExpectThunk"])
     ],
     dependencies: [
       .package(url: "https://github.com/ReSwift/ReSwift", .upToNextMajor(from: "6.0.0"))
@@ -17,6 +18,11 @@ let package = Package(
           "ReSwift"
         ],
         path: "ReSwift-Thunk"
+      ),
+      .target(
+        name: "ExpectThunk",
+        path: "ReSwift-ThunkTests/",
+        sources: ["ExpectThunk.swift"]
       )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ let package = Package(
 )
 ```
 
+Import testing support by importing `ReSwiftThunkTesting`
+
+```swift
+import ReSwiftThunkTesting
+```
+
 ## Checking out Source Code
 
 After checking out the project run `pod install` to get the latest supported version of [SwiftLint](https://github.com/realm/SwiftLint), which we use to ensure a consistent style in the codebase.

--- a/ReSwift-Thunk.xcodeproj/project.pbxproj
+++ b/ReSwift-Thunk.xcodeproj/project.pbxproj
@@ -684,7 +684,6 @@
 					"@loader_path/Frameworks",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
-				OTHER_SWIFT_FLAGS = "-D RESWIFT_THUNKTESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-ThunkTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -707,7 +706,6 @@
 					"@loader_path/Frameworks",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
-				OTHER_SWIFT_FLAGS = "-D RESWIFT_THUNKTESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-ThunkTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -847,7 +845,6 @@
 					"@loader_path/Frameworks",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
-				OTHER_SWIFT_FLAGS = "-D RESWIFT_THUNKTESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io..ReSwift-Thunk-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -871,7 +868,6 @@
 					"@loader_path/Frameworks",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
-				OTHER_SWIFT_FLAGS = "-D RESWIFT_THUNKTESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io..ReSwift-Thunk-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1049,7 +1045,6 @@
 					"@loader_path/../Frameworks",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
-				OTHER_SWIFT_FLAGS = "-D RESWIFT_THUNKTESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-ThunkTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,7 +1069,6 @@
 					"@loader_path/../Frameworks",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
-				OTHER_SWIFT_FLAGS = "-D RESWIFT_THUNKTESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-ThunkTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/ReSwift-ThunkTests/ExpectThunk.swift
+++ b/ReSwift-ThunkTests/ExpectThunk.swift
@@ -8,10 +8,7 @@
 
 import XCTest
 import ReSwift
-
-#if RESWIFT_THUNKTESTS
 import ReSwiftThunk
-#endif
 
 private struct ExpectThunkAssertion<T> {
     fileprivate let associated: T


### PR DESCRIPTION
This adds an ExpectThunk target to SPM. I have tested this in a codebase where we were previously manually copying the `ExpectThunk.swift` file into our codebase.

This also removes the `RESWIFT_THUNKTESTS` compiler directive. As far as I could find this flag was present only in targets that included the file. Removing it make integration into app tests simpler rather than having to add a build setting. If this is an issue it can be added back in and instructions to use it added to `README.md`